### PR TITLE
Feature to add is_private_data_present header in block_event kafka message

### DIFF
--- a/src/main/java/hlf/java/rest/client/listener/BlockEventListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/BlockEventListener.java
@@ -9,6 +9,7 @@ import hlf.java.rest.client.util.FabricEventParseUtil;
 import java.nio.charset.StandardCharsets;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hyperledger.fabric.sdk.BlockEvent;
 import org.hyperledger.fabric.sdk.BlockListener;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +64,8 @@ public class BlockEventListener implements BlockListener {
               transactionEvent.getTransactionActionInfo(0).getChaincodeIDName(),
               new String(
                   transactionEvent.getTransactionActionInfo(0).getChaincodeInputArgs(0),
-                  StandardCharsets.UTF_8));
+                  StandardCharsets.UTF_8),
+              StringUtils.isNotEmpty(privateDataPayload));
           BlockEventListener.blockTxId = transactionEvent.getTransactionID();
         }
       }

--- a/src/main/java/hlf/java/rest/client/service/EventPublishService.java
+++ b/src/main/java/hlf/java/rest/client/service/EventPublishService.java
@@ -35,6 +35,7 @@ public interface EventPublishService {
    * @param chaincodeName String chaincode name
    * @param channelName String Name of the channel where the event was generated.
    * @param functionName String Name of the function name.
+   * @param isPrivateDataPresent boolean flag to check if privateData present in payload
    * @return status boolean status of msg sent
    */
   boolean publishBlockEvents(
@@ -42,7 +43,8 @@ public interface EventPublishService {
       String fabricTxId,
       String channelName,
       String chaincodeName,
-      String functionName);
+      String functionName,
+      Boolean isPrivateDataPresent);
 
   /**
    * @param errorMsg contents of the error message

--- a/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
+++ b/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
@@ -139,7 +139,8 @@ public class EventPublishServiceImpl implements EventPublishService {
       String fabricTxId,
       String channelName,
       String chaincodeName,
-      String functionName) {
+      String functionName,
+      Boolean isPrivateDataPresent) {
     boolean status = true;
 
     try {
@@ -172,6 +173,13 @@ public class EventPublishServiceImpl implements EventPublishService {
           .add(
               new RecordHeader(
                   FabricClientConstants.FABRIC_EVENT_FUNC_NAME, functionName.getBytes()));
+
+      producerRecord
+          .headers()
+          .add(
+              new RecordHeader(
+                  FabricClientConstants.IS_PRIVATE_DATA_PRESENT,
+                  isPrivateDataPresent.toString().getBytes()));
 
       ListenableFuture<SendResult<String, String>> future = kafkaTemplate.send(producerRecord);
 

--- a/src/main/java/hlf/java/rest/client/util/FabricClientConstants.java
+++ b/src/main/java/hlf/java/rest/client/util/FabricClientConstants.java
@@ -19,7 +19,7 @@ public class FabricClientConstants {
   public static final String FABRIC_EVENT_FUNC_NAME = "function_name";
   public static final String FABRIC_TRANSIENT_KEY = "transient_key";
   public static final String FABRIC_COLLECTION_NAME = "collection_name";
-
+  public static final String IS_PRIVATE_DATA_PRESENT = "is_private_data_present";
   public static final String URI_PATH_BLOCKS = "/blocks/";
   public static final String URI_PATH_TRANSACTIONS = "/transactions/";
   public static final String URI_QUERY_PARAM_EVENT_TYPE = "eventType";


### PR DESCRIPTION
- Feature to add is_private_data_present header in block_event kafka message
 1. This kafka header flag help the kafka consuming application to identify the presence of private data without having to deserializing the whole payload.

Signed-off-by: Jitendra Das <jitendra.das0@walmart.com>