### PR TITLE
Jackson serialize PrivateData EmptyList field to empty string

### DIFF
--- a/src/main/java/hlf/java/rest/client/util/FabricEventParseUtil.java
+++ b/src/main/java/hlf/java/rest/client/util/FabricEventParseUtil.java
@@ -14,12 +14,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hyperledger.fabric.protos.ledger.rwset.Rwset;
 import org.hyperledger.fabric.protos.ledger.rwset.kvrwset.KvRwset;
 import org.hyperledger.fabric.protos.peer.EventsPackage;
 import org.hyperledger.fabric.sdk.BlockEvent;
 import org.hyperledger.fabric.sdk.BlockInfo;
 import org.hyperledger.fabric.sdk.TxReadWriteSetInfo;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
@@ -38,11 +40,11 @@ public class FabricEventParseUtil {
       EventsPackage.BlockAndPrivateData blockAndPrivateData)
       throws InvalidProtocolBufferException, JsonProcessingException {
     if (blockAndPrivateData == null) {
-      return "";
+      return StringUtils.EMPTY;
     }
     List<BlockEventPrivateDataWriteSet> writes =
         getPrivateDataBlockEventWriteSet(blockAndPrivateData.getPrivateDataMapMap());
-    return mapper.writeValueAsString(writes);
+    return CollectionUtils.isEmpty(writes) ? StringUtils.EMPTY : mapper.writeValueAsString(writes);
   }
 
   public static List<BlockEventWriteSet> getBlockEventWriteSet(


### PR DESCRIPTION
- Currently, if the privateData list is empty , jackson outputs it as json array i.e "[]" , to keep it inline with chaincode_event empty privateData, it is made empty string.

Signed-off-by:Jitendra Das <jitendra.das@walmartlabs.com>