### PR TITLE
Populate init flag from incoming request for fetching approved Orgs

### DIFF
--- a/src/main/java/hlf/java/rest/client/service/impl/ChaincodeOperationsServiceImpl.java
+++ b/src/main/java/hlf/java/rest/client/service/impl/ChaincodeOperationsServiceImpl.java
@@ -1,22 +1,11 @@
 package hlf.java.rest.client.service.impl;
 
-import static hlf.java.rest.client.exception.ErrorCode.CHAINCODE_PACKAGE_ID_VALIDATION_FAILED;
-import static hlf.java.rest.client.exception.ErrorCode.SEQUENCE_NUMBER_VALIDATION_FAILED;
-import static hlf.java.rest.client.model.ChaincodeOperationsType.approve;
-import static java.util.Objects.isNull;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 import hlf.java.rest.client.exception.ErrorCode;
 import hlf.java.rest.client.exception.ServiceException;
 import hlf.java.rest.client.model.ChaincodeOperations;
 import hlf.java.rest.client.model.ChaincodeOperationsType;
 import hlf.java.rest.client.service.ChaincodeOperationsService;
 import hlf.java.rest.client.service.HFClientWrapper;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.fabric.gateway.Gateway;
 import org.hyperledger.fabric.gateway.Network;
@@ -41,6 +30,18 @@ import org.hyperledger.fabric.sdk.exception.ProposalException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static hlf.java.rest.client.exception.ErrorCode.CHAINCODE_PACKAGE_ID_VALIDATION_FAILED;
+import static hlf.java.rest.client.exception.ErrorCode.SEQUENCE_NUMBER_VALIDATION_FAILED;
+import static hlf.java.rest.client.model.ChaincodeOperationsType.approve;
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Slf4j
 @Service
@@ -197,7 +198,7 @@ public class ChaincodeOperationsServiceImpl implements ChaincodeOperationsServic
             chaincodeCollectionConfigurationOptional.get());
       }
 
-      lifecycleCheckCommitReadinessRequest.setInitRequired(true);
+      lifecycleCheckCommitReadinessRequest.setInitRequired(chaincodeOperationsModel.getInitRequired());
 
       Collection<LifecycleCheckCommitReadinessProposalResponse>
           lifecycleSimulateCommitChaincodeDefinitionProposalResponse =


### PR DESCRIPTION
This PR contains the changeset for populating the `init` property of lifecycleCheckCommitReadinessRequest from the incoming `ChaincodeOperationsModel` passed by the client rather than setting it default as true.