### PR TITLE
Fix broken Event-Publisher flow caused by java version upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	</description>
 	<packaging>jar</packaging>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>8</java.version>
 		<jacoco.version>0.8.8</jacoco.version>
 		<protobuf.version>3.19.6</protobuf.version>
 		<spring-cloud.version>2021.0.3</spring-cloud.version>
@@ -312,8 +312,8 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>11</source>
-						<target>11</target>
+						<source>8</source>
+						<target>8</target>
 						<testExcludes>
 							<testExclude>**/MyAsset*</testExclude>
 						</testExcludes>

--- a/src/main/java/hlf/java/rest/client/listener/ChaincodeEventListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/ChaincodeEventListener.java
@@ -39,7 +39,7 @@ public class ChaincodeEventListener {
         log.info("Channel Name: {}", channelName);
 
         if (eventPublishService == null) {
-          log.info("Event Publish is disabled, chaincode event is no sent...");
+          log.info("Event Publish is disabled, skipping this Chaincode event");
           return;
         }
 

--- a/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
@@ -2,9 +2,6 @@ package hlf.java.rest.client.listener;
 
 import hlf.java.rest.client.config.FabricProperties;
 import hlf.java.rest.client.service.HFClientWrapper;
-import java.util.List;
-import java.util.regex.Pattern;
-import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.fabric.gateway.Gateway;
 import org.hyperledger.fabric.gateway.Network;
@@ -15,6 +12,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.CollectionUtils;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Configuration
@@ -40,7 +41,7 @@ public class FabricEventListener {
       if (!CollectionUtils.isEmpty(blockChannelNames)) {
 
         for (String channelName : blockChannelNames) {
-          log.info("channe; names{}", channelName);
+          log.info("channel names {}", channelName);
           Network network = gateway.getNetwork(channelName);
 
           if (null != network) {

--- a/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
+++ b/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
@@ -113,6 +113,8 @@ public class EventPublishServiceImpl implements EventPublishService {
                   FabricClientConstants.FABRIC_EVENT_TYPE,
                   FabricClientConstants.FABRIC_EVENT_TYPE_CHAINCODE.getBytes()));
 
+      log.info("Publishing Chaincode event to outbound topic {}", topicName);
+
       ListenableFuture<SendResult<String, String>> future = kafkaTemplate.send(producerRecord);
 
       future.addCallback(
@@ -189,6 +191,8 @@ public class EventPublishServiceImpl implements EventPublishService {
               new RecordHeader(
                   FabricClientConstants.IS_PRIVATE_DATA_PRESENT,
                   isPrivateDataPresent.toString().getBytes()));
+
+      log.info("Publishing Block event to outbound topic {}", topicName);
 
       ListenableFuture<SendResult<String, String>> future = kafkaTemplate.send(producerRecord);
 


### PR DESCRIPTION
This PR contains the changes to revert Java version upgrade which is potentially blocking the Chaincode Event publisher flow. 
Upgrade from 8 to 11 will be performed after verifying that no other dependencies of HLF connector has a strict dependency on version 8 or is incompatible with version 11.