### PR TITLE
Process Data-ingestion messages through Batched async mechanism to improve throughput.

### DIFF
--- a/src/main/java/hlf/java/rest/client/config/KafkaProperties.java
+++ b/src/main/java/hlf/java/rest/client/config/KafkaProperties.java
@@ -1,6 +1,5 @@
 package hlf.java.rest.client.config;
 
-import java.util.List;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 /**
  * The type Kafka properties is added for fetching Kafka properties as configuration and can be used
@@ -73,6 +74,8 @@ public class KafkaProperties {
     private String brokerHost;
     private String groupId;
     private String topic;
+    private int topicPartitions = 1;
+    private boolean enableParallelListenerCapabilities = false;
     private String saslJaasConfig;
 
     @Override

--- a/src/main/java/hlf/java/rest/client/config/WorkerPoolConfig.java
+++ b/src/main/java/hlf/java/rest/client/config/WorkerPoolConfig.java
@@ -1,0 +1,37 @@
+package hlf.java.rest.client.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@RefreshScope
+public class WorkerPoolConfig {
+
+  /**
+   * Core Pool and Max Pool size of executors are made configurable since these parameters are
+   * determined by the environment in which the Connector is running, like the number of CPU cores.
+   * If these values are not configured, fallback to the application defaults.
+   */
+  @Value("${executors.defaultExecutor.corePoolSize:20}")
+  private int defaultTaskExecutorCorePoolSize;
+
+  @Value("${executors.defaultExecutor.maxPoolSize:30}")
+  private int defaultExecutorMaxPoolSize;
+
+  @Value("${executors.defaultExecutor.waitQueueSize:400}")
+  private int defaultExecutorQueueSize;
+
+  /** A general-purpose, re-usable Task executor. */
+  @Bean
+  public TaskExecutor defaultTaskExecutor() {
+    ThreadPoolTaskExecutor defaultTaskExecutor = new ThreadPoolTaskExecutor();
+    defaultTaskExecutor.setCorePoolSize(defaultTaskExecutorCorePoolSize);
+    defaultTaskExecutor.setMaxPoolSize(defaultExecutorMaxPoolSize);
+    defaultTaskExecutor.setQueueCapacity(defaultExecutorQueueSize);
+    return defaultTaskExecutor;
+  }
+}

--- a/src/main/java/hlf/java/rest/client/listener/DynamicKafkaListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/DynamicKafkaListener.java
@@ -2,8 +2,8 @@ package hlf.java.rest.client.listener;
 
 import hlf.java.rest.client.config.KafkaConsumerConfig;
 import hlf.java.rest.client.config.KafkaProperties;
-import java.util.ArrayList;
-import java.util.List;
+import hlf.java.rest.client.exception.ServiceException;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,12 +12,20 @@ import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEven
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.listener.BatchAcknowledgingMessageListener;
+import org.springframework.kafka.listener.BatchListenerFailedException;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /*
  * This class is the configuration class for dynamically creating consumers to receiving the blockchain
@@ -28,6 +36,8 @@ import org.springframework.util.CollectionUtils;
 @ConditionalOnProperty("kafka.integration-points[0].brokerHost")
 public class DynamicKafkaListener {
 
+  private static final int MAX_CONCURRENT_LISTENERS_PER_CONSUMER = 6;
+
   private List<ConcurrentMessageListenerContainer> existingContainers = new ArrayList<>();
 
   @Autowired KafkaProperties kafkaProperties;
@@ -35,6 +45,8 @@ public class DynamicKafkaListener {
   @Autowired KafkaConsumerConfig kafkaConsumerConfig;
 
   @Autowired TransactionConsumer transactionConsumer;
+
+  @Autowired TaskExecutor defaultTaskExecutor;
 
   @EventListener
   public void handleEvent(ContextRefreshedEvent event) {
@@ -70,22 +82,100 @@ public class DynamicKafkaListener {
     ContainerProperties containerProperties = new ContainerProperties(consumer.getTopic());
     containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
 
-    containerProperties.setMessageListener(
-        new AcknowledgingMessageListener<String, String>() {
-          @Override
-          public void onMessage(
-              ConsumerRecord<String, String> message, Acknowledgment acknowledgment) {
-            transactionConsumer.listen(message, acknowledgment);
-          }
-        });
+    containerProperties.setMessageListener(determineMessageListenerForTransactions(consumer));
 
-    ConcurrentMessageListenerContainer container =
+    ConcurrentMessageListenerContainer<String, String> container =
         new ConcurrentMessageListenerContainer<>(factory, containerProperties);
+
+    int consumerListenerConcurrency = 1; // Kafka default if no concurrency is set.
+
+    if (consumer.isEnableParallelListenerCapabilities() && consumer.getTopicPartitions() > 1) {
+      consumerListenerConcurrency =
+          Math.min(consumer.getTopicPartitions(), MAX_CONCURRENT_LISTENERS_PER_CONSUMER);
+    }
+
+    container.setConcurrency(consumerListenerConcurrency);
 
     container.start();
     existingContainers.add(container);
     log.debug(
         "Created kafka message listener container"
             + container.metrics().keySet().iterator().next());
+  }
+
+  private Object determineMessageListenerForTransactions(KafkaProperties.Consumer consumer) {
+
+    return consumer.isEnableParallelListenerCapabilities()
+        ? getMultithreadedBatchAcknowledgingMessageListener()
+        : getPerRecordAcknowledgingListener();
+  }
+
+  /**
+   * A Message listener, where each Consumer container would get the list of Records fetched as part
+   * of poll() to process. The records are then supplied to an Async Task pool so that multiple
+   * individual Records can be processed in Parallel aynchronously. In case if one of the
+   * tasks/record fails with an Exception, we perform a partial Batch commit, in which the next
+   * poll() from the server would contain the non committed records of the previous Batch to
+   * process.
+   *
+   * @return
+   */
+  private Object getMultithreadedBatchAcknowledgingMessageListener() {
+    return new BatchAcknowledgingMessageListener<String, String>() {
+
+      @SneakyThrows
+      @Override
+      public void onMessage(
+          List<ConsumerRecord<String, String>> consumerRecords, Acknowledgment acknowledgment) {
+        log.debug("Consumer got assigned with a Batch of size : {}", consumerRecords.size());
+
+        List<CompletableFuture<Void>> transactionSubmissionTasks = new ArrayList<>();
+
+        // Dispatch workers for asynchronously processing Individual records
+        for (ConsumerRecord<String, String> message : consumerRecords) {
+          transactionSubmissionTasks.add(
+              CompletableFuture.runAsync(
+                  () -> {
+                    transactionConsumer.listen(message);
+                  },
+                  defaultTaskExecutor));
+        }
+
+        for (int i = 0; i < transactionSubmissionTasks.size(); i++) {
+          try {
+            transactionSubmissionTasks.get(i).get();
+          } catch (InterruptedException | ExecutionException e) {
+
+            final Throwable cause = e.getCause();
+
+            if (cause instanceof ServiceException) {
+              log.error(
+                  "One of the Consumer Record in Async Batch Processor failed with message {}",
+                  cause.getMessage());
+              throw new BatchListenerFailedException(
+                  "Failed to process a Consumer Record from the Batch", i);
+            }
+
+            if (cause instanceof InterruptedException) {
+              throw e;
+            }
+          }
+        }
+        // If the entire Records were processed successfully, Ack & commit the entire Batch
+        acknowledgment.acknowledge();
+      }
+    };
+  }
+
+  private Object getPerRecordAcknowledgingListener() {
+
+    return new AcknowledgingMessageListener<String, String>() {
+      @Override
+      public void onMessage(ConsumerRecord<String, String> message, Acknowledgment acknowledgment) {
+        transactionConsumer.listen(message);
+        // Manually ack the single Record
+        acknowledgment.acknowledge();
+      }
+    };
   }
 }


### PR DESCRIPTION
**Current Problem :** 
Presently, only a single Listener container is generated to consume messages from the Connectors ingestion Topic (across all the partitions) . This Listener sequentially processes each record returned by the internal ```poll()``` method which eventually affects the overall throughput of Connector, since the downstream ```TransactionConsumer#listen``` does a blocking call for writing transactions which could span for few seconds. 
Therefore given a scenario where ```TransactionConsumer#listen``` takes 2 seconds complete, in order to process 100 incoming records fetched by the ```poll()``` method it takes around 50 seconds. 

 **Proposed Fix :** 
Assign a dedicated Listener Container for each partition in the Topic, per connector instance (capped to a max of 6 Listeners, in order to avoid spawning a large number of Listeners for high-partitioned Topics ).
Each Listener gets a batch of Messages from the Partition it is assigned to, this batch is processed asynchronously by submitting it to a task executor in one go. The Listener thread defers the next poll until the entire records are processed parallelly. Once the batch is processed, Listener gets the next Batch from poll()
In case one of the records encounters an exception while processing parallelly, we perform a partial Batch commit and the failed and unprocessed records are sent again in the next poll()