### PR TITLE
Make input parameters optional for the MultiDataPayload

### DIFF
--- a/src/main/java/hlf/java/rest/client/controller/FabricClientController.java
+++ b/src/main/java/hlf/java/rest/client/controller/FabricClientController.java
@@ -4,6 +4,10 @@ import hlf.java.rest.client.model.ClientResponseModel;
 import hlf.java.rest.client.model.EventAPIResponseModel;
 import hlf.java.rest.client.model.MultiDataTransactionPayload;
 import hlf.java.rest.client.service.TransactionFulfillment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,11 +20,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Exposes REST endpoints to take actions from the client on the fabric ledger

--- a/src/main/java/hlf/java/rest/client/listener/TransactionConsumer.java
+++ b/src/main/java/hlf/java/rest/client/listener/TransactionConsumer.java
@@ -9,17 +9,16 @@ import hlf.java.rest.client.model.MultiDataTransactionPayload;
 import hlf.java.rest.client.service.EventPublishService;
 import hlf.java.rest.client.service.TransactionFulfillment;
 import hlf.java.rest.client.util.FabricClientConstants;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 /*
  * This class has the consumer logic for processing and adding transaction to fabric

--- a/src/main/java/hlf/java/rest/client/model/MultiDataTransactionPayload.java
+++ b/src/main/java/hlf/java/rest/client/model/MultiDataTransactionPayload.java
@@ -1,10 +1,12 @@
 package hlf.java.rest.client.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import java.util.List;
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MultiDataTransactionPayload extends ValidatedDataModel implements Serializable {
   private List<String> peerNames;
   private List<PrivateTransactionPayload> privatePayload;

--- a/src/main/java/hlf/java/rest/client/model/MultiPrivateDataTransactionPayloadValidator.java
+++ b/src/main/java/hlf/java/rest/client/model/MultiPrivateDataTransactionPayloadValidator.java
@@ -21,18 +21,21 @@ public class MultiPrivateDataTransactionPayloadValidator
           "Payload should consist of at-least one Private Data Payload or Public Payload");
     }
 
-    boolean hasValidPrivateData =
-        multiDataTransactionPayload.getPrivatePayload().stream()
-            .allMatch(
-                privateTransactionPayload ->
-                    StringUtils.isNotBlank(privateTransactionPayload.getKey())
-                        && StringUtils.isNotBlank(privateTransactionPayload.getData()));
-
     // If the model has Private data listed, ensure that it has mandatory fields populated
-    if (!CollectionUtils.isEmpty(multiDataTransactionPayload.getPrivatePayload())
-        && !hasValidPrivateData) {
-      throw new IllegalStateException(
-          "One or more Private Data representation is invalid, Private details should contain both Key name & Data");
+    // Have the nested if condition to avoid null pointer exceptions in case if the private
+    // payload is absent and was never sent.
+    if (!CollectionUtils.isEmpty(multiDataTransactionPayload.getPrivatePayload())) {
+      boolean hasValidPrivateData =
+          multiDataTransactionPayload.getPrivatePayload().stream()
+              .allMatch(
+                  privateTransactionPayload ->
+                      StringUtils.isNotBlank(privateTransactionPayload.getKey())
+                          && StringUtils.isNotBlank(privateTransactionPayload.getData()));
+
+      if (!hasValidPrivateData) {
+        throw new IllegalStateException(
+            "One or more Private Data representation is invalid, Private details should contain both Key name & Data");
+      }
     }
   }
 }

--- a/src/main/java/hlf/java/rest/client/service/TransactionFulfillment.java
+++ b/src/main/java/hlf/java/rest/client/service/TransactionFulfillment.java
@@ -3,12 +3,11 @@ package hlf.java.rest.client.service;
 import hlf.java.rest.client.model.ClientResponseModel;
 import hlf.java.rest.client.model.EventAPIResponseModel;
 import hlf.java.rest.client.model.MultiDataTransactionPayload;
+import java.util.List;
+import java.util.Optional;
 import org.hyperledger.fabric.gateway.ContractException;
 import org.hyperledger.fabric.gateway.GatewayRuntimeException;
 import org.springframework.http.ResponseEntity;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Handles the business logic for processing transaction related actions affecting the ledger


### PR DESCRIPTION
1. Peer names are not always mandatory in the transaction request.
2. Peer private payload is not always mandatory in the transaction request.
3. Minor refactoring.