### PR TITLE
Use Framework provided html escape utility over third party libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,11 +163,6 @@
 			<artifactId>log4j-api</artifactId>
 			<version>2.18.0</version>
 		</dependency>
-		<dependency>
-			<groupId>org.owasp.esapi</groupId>
-			<artifactId>esapi</artifactId>
-			<version>2.5.2.0</version>
-		</dependency>
 		<!-- Testing related dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/hlf/java/rest/client/config/FabricProperties.java
+++ b/src/main/java/hlf/java/rest/client/config/FabricProperties.java
@@ -64,9 +64,9 @@ public class FabricProperties {
   @ConditionalOnProperty(prefix = "fabric.events", name = "enable", havingValue = "true")
   public static class Events {
     private boolean enable;
-    private List<String>
-        chaincode; // TODO: This will removed or deprecated and the property 'chaincodeDetails' will
-    // be preferred for providing Chaincode details for Event subscription
+    // TODO: This will be removed or deprecated and the property 'chaincodeDetails' will be
+    // preferred for providing Chaincode details for Event subscription
+    private List<String> chaincode;
     private List<String> block;
     private List<ChaincodeDetails> chaincodeDetails;
   }

--- a/src/main/java/hlf/java/rest/client/controller/ChaincodeOperationsController.java
+++ b/src/main/java/hlf/java/rest/client/controller/ChaincodeOperationsController.java
@@ -6,7 +6,6 @@ import hlf.java.rest.client.service.ChaincodeOperationsService;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.owasp.esapi.ESAPI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.HtmlUtils;
 
 @Slf4j
 @RestController
@@ -42,7 +42,7 @@ public class ChaincodeOperationsController {
             operationsType,
             Optional.ofNullable(collectionConfigFile));
 
-    operationResponse = ESAPI.encoder().encodeForHTML(operationResponse);
+    operationResponse = HtmlUtils.htmlEscape(operationResponse);
 
     return new ResponseEntity<>(operationResponse, HttpStatus.OK);
   }
@@ -56,7 +56,7 @@ public class ChaincodeOperationsController {
     String operationResponse =
         chaincodeOperationsService.getCurrentSequence(networkName, chaincodeName, chaincodeVersion);
 
-    operationResponse = ESAPI.encoder().encodeForHTML(operationResponse);
+    operationResponse = HtmlUtils.htmlEscape(operationResponse);
 
     return new ResponseEntity<>(operationResponse, HttpStatus.OK);
   }
@@ -68,9 +68,10 @@ public class ChaincodeOperationsController {
       @RequestParam("chaincode_version") @Validated String chaincodeVersion) {
 
     String operationResponse =
-        chaincodeOperationsService.getCurrentSequence(networkName, chaincodeName, chaincodeVersion);
+        chaincodeOperationsService.getCurrentPackageId(
+            networkName, chaincodeName, chaincodeVersion);
 
-    operationResponse = ESAPI.encoder().encodeForHTML(operationResponse);
+    operationResponse = HtmlUtils.htmlEscape(operationResponse);
 
     return new ResponseEntity<>(operationResponse, HttpStatus.OK);
   }

--- a/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
@@ -92,8 +92,8 @@ public class FabricEventListener {
        * will be given to register Event-listener via the 'Contract' object and registering events
        * through 'chaincodeChannelNames' will be skipped regardless whether it's populated or not.
        *
-       * <p>P.S it is recommended to 'Contract' object for registering Event-Listeners over
-       * registering it througth 'Channel' Object.
+       * <p>P.S it is recommended to use 'Contract' object for registering Event-Listeners over
+       * registering it through 'Channel' Object.
        */
       if (!CollectionUtils.isEmpty(chaincodeDetails)) {
 


### PR DESCRIPTION
This changeset contains few minor refactorings like fixing code comments and using Framework provided HTML escape utility instead of using a third party library.