### PR TITLE
Support multiple outbound topics for publishing blockchain events

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,7 +12,7 @@ cd "$(dirname "$0")"
 source pull-fabric-images.sh
 
 pushd ../src/test/java/fabricSetup/ >/dev/null
-docker-compose up --force-recreate -d
+docker compose up --force-recreate -d
 popd >/dev/null && cd ..
 
 docker ps -a
@@ -22,4 +22,4 @@ export MAVEN_OPTS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Sl
 mvn clean test-compile failsafe:integration-test -Dmaven.test.failure.ignore=false
 
 pushd src/test/java/fabricSetup/ >/dev/null
-docker-compose down --volumes
+docker compose down --volumes

--- a/src/main/java/hlf/java/rest/client/config/FabricProperties.java
+++ b/src/main/java/hlf/java/rest/client/config/FabricProperties.java
@@ -68,14 +68,21 @@ public class FabricProperties {
     // preferred for providing Chaincode details for Event subscription
     private List<String> chaincode;
     private boolean standardCCEventEnabled;
-    private List<String> block;
+    private List<BlockDetails> blockDetails;
     private List<ChaincodeDetails> chaincodeDetails;
+  }
+
+  @Data
+  public static class BlockDetails {
+    private String channelName;
+    private List<String> listenerTopics;
   }
 
   @Data
   public static class ChaincodeDetails {
     private String channelName;
     private String chaincodeId;
+    private List<String> listenerTopics;
   }
 
   /**

--- a/src/main/java/hlf/java/rest/client/config/KafkaProducerConfig.java
+++ b/src/main/java/hlf/java/rest/client/config/KafkaProducerConfig.java
@@ -1,8 +1,14 @@
 package hlf.java.rest.client.config;
 
+import hlf.java.rest.client.exception.ErrorCode;
+import hlf.java.rest.client.exception.ServiceException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,26 +16,26 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.MicrometerProducerListener;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.core.RoutingKafkaTemplate;
 
 /** This class is the configuration class for sending to Chaincode event to eventHub/Kafka Topic. */
 @Slf4j
 @Configuration
-@ConditionalOnProperty("kafka.event-listener.brokerHost")
+@ConditionalOnProperty("kafka.event-listeners[0].brokerHost")
 @RefreshScope
 public class KafkaProducerConfig extends BaseKafkaConfig {
 
-  private static final String PRODUCER_ALL_ACKS = "all";
   private static final int RETRIES_CONFIG_FOR_AT_MOST_ONCE = 0;
 
   @Autowired private KafkaProperties kafkaProperties;
 
   @Autowired private MeterRegistry meterRegistry;
 
-  public ProducerFactory<String, String> eventProducerFactory(
+  public ProducerFactory<Object, Object> eventProducerFactory(
       KafkaProperties.Producer kafkaProducerProperties) {
     Map<String, Object> props = new HashMap<>();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProducerProperties.getBrokerHost());
@@ -60,7 +66,7 @@ public class KafkaProducerConfig extends BaseKafkaConfig {
 
     log.info("Generating Kafka producer factory..");
 
-    DefaultKafkaProducerFactory<String, String> defaultKafkaProducerFactory =
+    DefaultKafkaProducerFactory<Object, Object> defaultKafkaProducerFactory =
         new DefaultKafkaProducerFactory<>(props);
     defaultKafkaProducerFactory.addListener(new MicrometerProducerListener<>(meterRegistry));
 
@@ -69,8 +75,24 @@ public class KafkaProducerConfig extends BaseKafkaConfig {
 
   @Bean
   @RefreshScope
-  public KafkaTemplate<String, String> kafkaTemplate() {
-    return new KafkaTemplate<>(eventProducerFactory(kafkaProperties.getEventListener()));
+  public RoutingKafkaTemplate routingTemplate(GenericApplicationContext context) {
+
+    Set<String> topicSet = new HashSet<>();
+    Map<Pattern, ProducerFactory<Object, Object>> map = new LinkedHashMap<>();
+    for (KafkaProperties.EventProducer eventProducer : kafkaProperties.getEventListeners()) {
+      if (topicSet.contains(eventProducer.getTopic())) {
+        throw new ServiceException(ErrorCode.NOT_SUPPORTED, "Topic name should be unique");
+      }
+      topicSet.add(eventProducer.getTopic());
+      ProducerFactory<Object, Object> defaultKafkaProducerFactory =
+          eventProducerFactory(eventProducer);
+      context.registerBean(
+          eventProducer.getTopic() + "PF",
+          ProducerFactory.class,
+          () -> defaultKafkaProducerFactory);
+      map.put(Pattern.compile(eventProducer.getTopic()), defaultKafkaProducerFactory);
+    }
+    return new RoutingKafkaTemplate(map);
   }
 
   @Override

--- a/src/main/java/hlf/java/rest/client/config/KafkaProperties.java
+++ b/src/main/java/hlf/java/rest/client/config/KafkaProperties.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
 public class KafkaProperties {
 
   private List<Consumer> integrationPoints;
-  private EventProducer eventListener;
+  private List<EventProducer> eventListeners;
   private Producer failedMessageListener;
 
   @Getter

--- a/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
+++ b/src/main/java/hlf/java/rest/client/listener/FabricEventListener.java
@@ -47,13 +47,15 @@ public class FabricEventListener {
     startEventListener();
   }
 
-  public void startEventListener() {
+  private void startEventListener() {
 
     try {
-      List<String> blockChannelNames = fabricProperties.getEvents().getBlock();
-      if (!CollectionUtils.isEmpty(blockChannelNames)) {
+      List<FabricProperties.BlockDetails> blockDetailsList =
+          fabricProperties.getEvents().getBlockDetails();
+      if (!CollectionUtils.isEmpty(blockDetailsList)) {
 
-        for (String channelName : blockChannelNames) {
+        for (FabricProperties.BlockDetails blockDetails : blockDetailsList) {
+          String channelName = blockDetails.getChannelName();
           log.info("channel names {}", channelName);
           Network network = gateway.getNetwork(channelName);
 

--- a/src/main/java/hlf/java/rest/client/service/EventPublishService.java
+++ b/src/main/java/hlf/java/rest/client/service/EventPublishService.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
  * The EventPublishService is a service class, which include the kafka template. It sends the
  * Message to the Event Kafka message topic
  */
-@ConditionalOnProperty("kafka.event-listener.brokerHost")
+@ConditionalOnProperty("kafka.event-listeners[0].brokerHost")
 public interface EventPublishService {
 
   /**
@@ -25,9 +25,8 @@ public interface EventPublishService {
    * @param eventName String chaincode event-name
    * @param channelName String Name of the channel where the event was generated.
    * @param messageKey associated key for the payload.
-   * @return status boolean status of msg sent
    */
-  boolean publishChaincodeEvents(
+  void publishChaincodeEvents(
       final String payload,
       String chaincodeName,
       String fabricTxId,
@@ -42,9 +41,8 @@ public interface EventPublishService {
    * @param channelName String Name of the channel where the event was generated.
    * @param functionName String Name of the function name.
    * @param isPrivateDataPresent boolean flag to check if privateData present in payload
-   * @return status boolean status of msg sent
    */
-  boolean publishBlockEvents(
+  void publishBlockEvents(
       final String payload,
       String fabricTxId,
       String channelName,

--- a/src/main/java/hlf/java/rest/client/service/EventPublishService.java
+++ b/src/main/java/hlf/java/rest/client/service/EventPublishService.java
@@ -14,16 +14,6 @@ public interface EventPublishService {
    * @param fabricTxId String Fabric transaction ID
    * @param eventName String chaincode event-name
    * @param channelName String Name of the channel where the event was generated.
-   * @return status boolean status of msg sent
-   */
-  boolean sendMessage(
-      final String payload, String fabricTxId, String eventName, String channelName);
-
-  /**
-   * @param payload String message payload
-   * @param fabricTxId String Fabric transaction ID
-   * @param eventName String chaincode event-name
-   * @param channelName String Name of the channel where the event was generated.
    * @param messageKey associated key for the payload.
    */
   void publishChaincodeEvents(

--- a/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
+++ b/src/main/java/hlf/java/rest/client/service/impl/EventPublishServiceImpl.java
@@ -29,64 +29,6 @@ public class EventPublishServiceImpl implements EventPublishService {
   @Autowired private RoutingKafkaTemplate routingKafkaTemplate;
 
   @Override
-  public boolean sendMessage(String msg, String fabricTxId, String eventName, String channelName) {
-
-    log.debug("Send Event Message - " + msg);
-
-    boolean status = true;
-
-    try {
-
-      ProducerRecord<Object, Object> producerRecord =
-          new ProducerRecord<>(
-              kafkaProperties.getEventListeners().get(0).getTopic(),
-              String.valueOf(msg.hashCode()),
-              msg);
-
-      producerRecord
-          .headers()
-          .add(
-              new RecordHeader(FabricClientConstants.FABRIC_TRANSACTION_ID, fabricTxId.getBytes()));
-      producerRecord
-          .headers()
-          .add(new RecordHeader(FabricClientConstants.FABRIC_EVENT_NAME, eventName.getBytes()));
-      producerRecord
-          .headers()
-          .add(new RecordHeader(FabricClientConstants.FABRIC_CHANNEL_NAME, channelName.getBytes()));
-
-      ListenableFuture<SendResult<Object, Object>> future =
-          routingKafkaTemplate.send(producerRecord);
-
-      future.addCallback(
-          new ListenableFutureCallback<SendResult<Object, Object>>() {
-
-            @Override
-            public void onSuccess(SendResult<Object, Object> result) {
-              log.info(
-                  "Sent message '{}' to partition {} for offset {}",
-                  msg,
-                  result.getRecordMetadata().partition(),
-                  result.getRecordMetadata().offset());
-            }
-
-            @Override
-            public void onFailure(Throwable ex) {
-              log.error(
-                  "Failed to send message event for Transaction ID {} due to {}",
-                  fabricTxId,
-                  ex.getMessage());
-            }
-          });
-
-    } catch (Exception ex) {
-      status = false;
-      log.error("Error sending message - " + ex.getMessage());
-    }
-
-    return status;
-  }
-
-  @Override
   public void publishChaincodeEvents(
       String payload,
       String chaincodeName,

--- a/src/main/resources/application.template
+++ b/src/main/resources/application.template
@@ -32,13 +32,15 @@ fabric:
     enable: true
     standardCCEventEnabled: boolean (if set to true then the chaincode event is attempted at deserializing in the connector)
     chaincode: <comma separated list of channels> (Note : Will soon be deprecated / removed)
-    block: <comma separated list of channels>
+    blockDetails:
+      - channelName: Name of the Channel
+        listenerTopics: topics to which event messages will be sent
     chaincodeDetails:
-           -
-             channelName: Name of the Channel
-             chaincodeId: chaincode-id of the deployed chaincode in this Channel
+      - channelName: Name of the Channel
+        chaincodeId: chaincode-id of the deployed chaincode in this Channel
+        listenerTopics: topics to which event messages will be sent
 kafka:
-  integration-points: <Note : This is a list and Multiple intgration points can be configured)
+  integration-points: <Note : This is a list and Multiple integration points can be configured>
     - groupId: test_group_id
       enableParallelListenerCapabilities: boolean
       topicPartitions: <Number of Partitions in the Topic>
@@ -47,15 +49,16 @@ kafka:
       ssl-enabled: boolean
       security-protocol: <Only supports SSL>
       ssl-keystore-base64: <if ssl-enabled is true, provide the Base64 encoded value of keystore file>
-      ssl-truststore-base64: <if ssl-enabled is true, provide the Base64 encoded value of Trsutstore file>
+      ssl-truststore-base64: <if ssl-enabled is true, provide the Base64 encoded value of Truststore file>
       offsetResetPolicy: <possible values are earliest / latest> if not provided, default will be latest.
-  event-listener:
-    brokerHost: <Comma separated list of boostrap servers>
-    topic: <topic to publish Block or Chaincode Events>
-    ssl-enabled: boolean
-    security-protocol: <Only supports SSL>
-    listenToFailedMessages: boolean <set as true if you wish to recieve errored Transaction records back to this topic>
-    enableIdempotence: boolean, enable strict Kafka producer idempotence
+  event-listeners: <Note : This is a list and Multiple event listeners can be configured>
+    -
+        brokerHost: <Comma separated list of boostrap servers>
+        topic: <default topic to publish Block or Chaincode Events if no topic configured at individual level of event>
+        ssl-enabled: boolean
+        security-protocol: <Only supports SSL>
+        listenToFailedMessages: boolean <set as true if you wish to receive errored Transaction records back to this topic>
+        enableIdempotence: boolean, enable strict Kafka producer idempotence
 
   failed-message-listener: <Note, if you wish to receive errored Transactions to a dedicated topic, these details should be filled up>
     brokerHost: <Comma separated list of boostrap servers>
@@ -65,7 +68,7 @@ kafka:
 dedupe:
     enable: boolean, if enabled, the runtime instance of Connector utilises an in-memory recency cache that would validate a recent submission of Transaction prior to emitting an event with the matching Transaction ID.
     recency-window-size: applicable only if dedupe is enabled, defines the recency cache size.
-    recency-window-expiry-in-minutes: applicable only if dedupe is enabled, defines the recency cache TTL in minites
+    recency-window-expiry-in-minutes: applicable only if dedupe is enabled, defines the recency cache TTL in minutes
 ---
 spring:
   profiles: container

--- a/src/test/java/hlf/java/rest/client/integration/ConfigHandlerControllerIntegrationTest.java
+++ b/src/test/java/hlf/java/rest/client/integration/ConfigHandlerControllerIntegrationTest.java
@@ -54,7 +54,8 @@ public class ConfigHandlerControllerIntegrationTest {
     Assertions.assertEquals(
         TestConfiguration.FABRIC_PROPERTIES_EVENTS, fabricProperties.getEvents().toString());
     Assertions.assertEquals(
-        TestConfiguration.KAFKA_PROPERTIES_PRODUCER, kafkaProperties.getEventListener().toString());
+        TestConfiguration.KAFKA_PROPERTIES_PRODUCER,
+        kafkaProperties.getEventListeners().get(0).toString());
     Assertions.assertEquals(
         TestConfiguration.KAFKA_CONSUMER_PROPERTIES,
         kafkaProperties.getIntegrationPoints().toString());
@@ -81,7 +82,7 @@ public class ConfigHandlerControllerIntegrationTest {
     static String FABRIC_PROPERTIES_CLIENT =
         "FabricProperties.Client(rest=FabricProperties.Client.Rest(apikey=expected-key))";
     static String FABRIC_PROPERTIES_EVENTS =
-        "FabricProperties.Events(enable=true, chaincode=[chaincode12, chaincode2], standardCCEventEnabled=false, block=[block111, block2], chaincodeDetails=null)";
+        "FabricProperties.Events(enable=true, chaincode=[chaincode12, chaincode2], standardCCEventEnabled=false, blockDetails=[FabricProperties.BlockDetails(channelName=block111, listenerTopics=[topic-1])], chaincodeDetails=null)";
     static String KAFKA_PROPERTIES_PRODUCER =
         "Producer{brokerHost='localhost:8087', topic='hlf-offchain-topic1', saslJaasConfig='null'}";
     static String KAFKA_CONSUMER_PROPERTIES =

--- a/src/test/resources/application-default-consumer.yml
+++ b/src/test/resources/application-default-consumer.yml
@@ -15,7 +15,7 @@ fabric:
     enable: true
     chaincode: []
     chaincodeDetails: []
-    block: []
+    blockDetails: []
   client:
     rest:
       apikey: 6uoIAnR
@@ -26,12 +26,12 @@ kafka:
       topic: test-consumer-inbound-topic
       config-id: 892019
       ssl-enabled: false
-  event-listener:
-    ssl-enabled: false
-    brokerHost: localhost:9092
-    topic: test-publisher-event-topice
-    enable-idempotence: true
-    enable-at-most-once-semantics: true
+  event-listeners:
+    - ssl-enabled: false
+      brokerHost: localhost:9092
+      topic: test-publisher-event-topice
+      enable-idempotence: true
+      enable-at-most-once-semantics: true
 management:
   endpoints:
     web:

--- a/src/test/resources/application-per-partition-consumer.yml
+++ b/src/test/resources/application-per-partition-consumer.yml
@@ -15,7 +15,7 @@ fabric:
     enable: true
     chaincode: []
     chaincodeDetails: []
-    block: []
+    blockDetails: []
   client:
     rest:
       apikey: 6uoIAnR
@@ -27,11 +27,11 @@ kafka:
       config-id: 892019
       ssl-enabled: false
       topicPartitions: 12
-  event-listener:
-    ssl-enabled: false
-    brokerHost: localhost:9092
-    topic: test-publisher-event-topic
-    enable-idempotence: true
+  event-listeners:
+    - ssl-enabled: false
+      brokerHost: localhost:9092
+      topic: test-publisher-event-topic
+      enable-idempotence: true
   failed-message-listener:
     brokerHost: localhost:9092
     topic: test-consumer-dlt

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -43,11 +43,11 @@ kafka:
       brokerHost: localhost:9094
       groupId: fabric-consumer
       topic: hlf-integration-topic2
-  event-listener:
-    brokerHost: localhost:9093
-    topic: hlf-offchain-topic
-    enable-idempotence: true
-    enable-at-most-once-semantics: true
+  event-listeners:
+    - brokerHost: localhost:9093
+      topic: hlf-offchain-topic
+      enable-idempotence: true
+      enable-at-most-once-semantics: true
 dedupe:
   enable: false
 ---
@@ -67,7 +67,9 @@ fabric:
   events:
     enable: false
     chaincode: channel1
-    block: channel1
+    blockDetails:
+      - channelName: channel1
+        listenerTopics: topic-1
   client:
     rest:
       apikey: abc

--- a/src/test/resources/integration/sample-application.yml
+++ b/src/test/resources/integration/sample-application.yml
@@ -38,7 +38,9 @@ fabric:
     enable: true
     standardCCEventEnabled: false
     chaincode: chaincode12, chaincode2
-    block: block111, block2
+    blockDetails:
+      - channelName: block111
+        listenerTopics: topic-1
 kafka:
   integration-points:
     -
@@ -49,9 +51,9 @@ kafka:
       brokerHost: localhost:8087
       groupId: fabric-consumer1
       topic: hlf-integration-topic21
-  event-listener:
-    brokerHost: localhost:8087
-    topic: hlf-offchain-topic1
+  event-listeners:
+    - brokerHost: localhost:8087
+      topic: hlf-offchain-topic1
 
 
 ---


### PR DESCRIPTION
With this change, based on configurations the block/chaincode events can now be sent to multiple topics. 